### PR TITLE
add electron-builder script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # production
 /build
+/apps
 
 # misc
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
   "scripts": {
     "start": "node scripts/start.js",
     "build": "node scripts/build.js",
+    "premake": "PUBLIC_URL=./ node scripts/build.js",
     "test": "node scripts/test.js",
     "deploy": "gh-pages -d build",
     "lint": "eslint './src/**/*.{ts,tsx}'",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -104,6 +104,10 @@ checkBrowsers(paths.appPath, isInteractive)
         buildFolder,
         useYarn
       );
+
+      addElectronConfig().catch((err) => {
+        console.log(err);
+      });
     },
     err => {
       console.log(chalk.red('Failed to compile.\n'));
@@ -188,4 +192,42 @@ function copyPublicFolder() {
     dereference: true,
     filter: file => file !== paths.appHtml,
   });
+}
+
+// Create the config file for Electron
+function addElectronConfig() {
+  try {
+    const packageJsonOrigin = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+
+    const packageJson = JSON.stringify({
+      "name": packageJsonOrigin.name,
+      "version": packageJsonOrigin.version,
+      "description": packageJsonOrigin.description || 'native app created with electron',
+      "author": packageJsonOrigin.author || '',
+      "main": "electron-render.js",
+      "scripts": {
+        "electron": "electron .",
+        "make": "electron-builder build -m zip -w zip"
+      },
+      "build": {
+        "directories": {
+          "output": "../apps",
+          "buildResources": "."
+        },
+        "productName": "Puppy Playground",
+        "copyright": "Copyright Â© 2019 Mario"
+      },
+      "devDependencies": {
+        "electron": "^7.1.2",
+        "electron-builder": "^21.2.0"
+      }
+    });
+
+    fs.writeFileSync('build/package.json', packageJson);
+    fs.copyFileSync('scripts/electron-render.js', 'build/electron-render.js');
+    fs.copyFileSync('public/image/logo.png', 'build/icon.png');
+    return Promise.resolve(true);
+  } catch (err) {
+    return Promise.reject(err)
+  }
 }

--- a/scripts/electron-render.js
+++ b/scripts/electron-render.js
@@ -1,0 +1,41 @@
+const { app, BrowserWindow } = require('electron')
+
+let win
+
+function createWindow() {
+  //ウインドウの作成
+  win = new BrowserWindow({
+    width: 800,
+    height: 600,
+    webPreferences: {
+      nodeIntegration: true, //Electron6から必要らしい
+    }
+  })
+
+  //ウインドウに表示する内容
+  win.loadFile('index.html')
+
+  //ウインドウが閉じられたとき
+  win.on('closed', () => {
+    win = null
+  })
+}
+
+//アプリが初期化されたとき（起動されたとき）
+app.on('ready', () => {
+  createWindow();
+})
+
+//全ウインドウが閉じられたとき
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit()
+  }
+})
+
+//アクティブになったとき（MacだとDockがクリックされたとき）
+app.on('activate', () => {
+  if (win === null) {
+    createWindow()
+  }
+})


### PR DESCRIPTION
# Appのビルド方法
+ `npm run premake`でrootパスを`LIVE2019/`から`./`に変更した状態でreactのビルド
+ `cd build`で中に入ったら`npm i`でdevDependenciesのelectronとelectron-builderをinstall
+ `npm run make`でexeの入ったzip(for windows)とappの入ったzip(for mac)をapps配下に生成

※ build内で使うpackage.jsonはbuild.js内に直書きしてます
※ `npm run electron`でビルドせずにテストが可能